### PR TITLE
Update NAPALM LLDP fact name

### DIFF
--- a/LLDP-to-Graph/graph.j2
+++ b/LLDP-to-Graph/graph.j2
@@ -2,12 +2,12 @@ graph network {
 {% for local in play_hosts %}
   "{{local}}" [shape=record,
     label="<node>{{local}}|{ {% 
-    for ifname,lldp in hostvars[local].lldp_neighbors|dictsort 
+    for ifname,lldp in hostvars[local].napalm_lldp_neighbors|dictsort 
     %}<{{- ifname -}}>{{- ifname -}}{% if not(loop.last) %}|{% endif %}{%
     endfor %} }"];
 {% endfor %}
 {% for local in play_hosts %}
-{%  for ifname,lldp in hostvars[local].lldp_neighbors|dictsort if lldp|length > 0 %}
+{%  for ifname,lldp in hostvars[local].napalm_lldp_neighbors|dictsort if lldp|length > 0 %}
 {%   for n in lldp if local < n.hostname or n.hostname not in play_hosts %}
   "{{local}}":"{{ifname}}" -- "{{n.hostname}}":"{{n.port}}";
 {%   endfor %}


### PR DESCRIPTION
Fact lldp_neighbors is not found. Showing the ansible_facts after collecting neighbors via NAPALM reveals the fact name may have changed to napalm_lldp_neighbors. network.dot successfully generated with updated fact name.

(Hopefully I've done this correctly, I've never submitted a patch for anything before...)