### PR TITLE
Directory LLDP-to-Graph-pyeznc contains a playbook that uses native juniper's libraries

### DIFF
--- a/LLDP-to-Graph-pyeznc/LLDP-to-Graph-eznc.yml
+++ b/LLDP-to-Graph-pyeznc/LLDP-to-Graph-eznc.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Fetch LLDP information from network elements and produce physical topology
+  hosts: all
+  gather_facts: no
+  connection: local
+
+  tasks:
+
+    - name: Get LLDP neighbors using table/views
+      junos_get_table:
+        table=LLDPNeighborTable
+        file=lldp.yml 
+        host={{ inventory_hostname }} 
+        port=22
+      register: lldp_results
+
+    - name: print
+      debug: msg="{{ lldp_results }}"
+
+    - name: Generate graph description file
+      template: src={{template|default('graph-eznc.j2')}} dest=./{{output|default('network.dot')}}
+      run_once: true
+
+  roles:
+    - ansible-junos-stdlib

--- a/LLDP-to-Graph-pyeznc/README.md
+++ b/LLDP-to-Graph-pyeznc/README.md
@@ -1,0 +1,38 @@
+# Generate network topology graph from LLDP neighbors using junos-eznc
+
+The *LLDP-to-Graph-eznc* Ansible playbook uses LLDP neighbor data collected
+with Juniper's stdlib ansible module to generate network diagram in *Graphviz* .dot file format.
+
+## Installation guide
+
+The playbooks were tested with these versions of Ansible, junos-eznc and  ansible-junos-stdlib:
+
+* Ansible 2.4
+* junos-eznc 2.1.7
+* ansible-junos-stdlib 2.0.0
+
+Notes:
+
+* The playbook collects data only from Juniper equipment using the default junos-eznc and ansible-junos-stdlib libraries.
+
+
+## Usage
+
+* Create your inventory file named ***hosts***. 
+* Install ***junos-eznc*** using the pip tool inside your virtualenv,
+* Install the ***ansible-junos-stdlib*** from https://github.com/Juniper/ansible-junos-stdlib in the roles subdirectory,
+* Install *graphviz*
+* Generate the network topology file with
+```
+ansible-playbook LLDP-to-Graph-pyeznc.yml
+```
+* Generate the network diagram (in PNG format) with
+```
+dot -Tpng network.dot >network.png
+```
+* Enjoy, modify and submit a pull request when you add something awesome
+
+## More information
+
+* [Ansible for Networking Engineers](http://www.ipspace.net/Ansible_for_Networking_Engineers) online course ([contents](https://my.ipspace.net/bin/list?id=AnsibleOC))
+* [Building Network Automation Solutions](http://www.ipspace.net/Building_Network_Automation_Solutions) online course ([contents](https://my.ipspace.net/bin/list?id=NetAutSol))

--- a/LLDP-to-Graph-pyeznc/graph-eznc.j2
+++ b/LLDP-to-Graph-pyeznc/graph-eznc.j2
@@ -1,0 +1,16 @@
+graph network {
+{% for local in play_hosts %}
+  "{{local}}" [shape=record,
+    label="<node>{{local}}|{ {% 
+    for key in hostvars[local].lldp_results.resource|sort(attribute='local_int')
+    %}<{{- key['local_int'] -}}>{{- key['local_int'] -}}{% if not(loop.last) %}|{% endif %}{%
+    endfor %} }"];
+{% endfor %}
+{% for local in play_hosts %}
+{%  for x in hostvars[local].lldp_results.resource|sort(attribute='local_int') if x|length > 0 %}
+{%   if local < x.remote_sysname or x.remote_sysname not in play_hosts %}
+  "{{local}}":"{{ x.local_int }}" -- "{{x.remote_sysname}}":"{{x.remote_port_id}}";
+{%   endif  %}
+{%  endfor %}
+{% endfor %}
+}

--- a/LLDP-to-Graph-pyeznc/hosts
+++ b/LLDP-to-Graph-pyeznc/hosts
@@ -1,0 +1,3 @@
+[your_tag_if_any]
+router1.example.com
+router2.example.com

--- a/LLDP-to-Graph-pyeznc/roles/README.md
+++ b/LLDP-to-Graph-pyeznc/roles/README.md
@@ -1,0 +1,2 @@
+## Directory contents
+Put ansible-junos-stdlib from https://github.com/Juniper/ansible-junos-stdlib inside this directory


### PR DESCRIPTION
Directory LLDP-to-Graph-pyeznc contains a playbook that uses native juniper's libraries (ansible-junos-stdlib & py-junos-eznc) to draw a topology based on LLDP adjacencies.