### PR TITLE
Added playbook for rolling out LLDP

### DIFF
--- a/LLDP-to-Graph/README.md
+++ b/LLDP-to-Graph/README.md
@@ -37,6 +37,8 @@ ansible-playbook LLDP-to-Graph.yml
 ```
 dot -Tpng network.dot >network.png
 ```
+The 'disable-LLDP-on-edge' playbook can be used to rollout LLDP on STP P2P links while keeping it disabled on STP edge ports. This keeps the topology free from LLDP speaking hosts.
+
 * Enjoy, modify and submit a pull request when you add something awesome
 
 ## More information

--- a/LLDP-to-Graph/disable-LLDP-on-edge.yml
+++ b/LLDP-to-Graph/disable-LLDP-on-edge.yml
@@ -1,0 +1,38 @@
+# created by abaretta@falco-networks.com
+---
+- hosts: all
+  connection: network_cli
+  gather_facts: no
+
+  tasks:
+  - name: Get IOS STP edge ports
+    ios_command:
+      commands:
+         - "sh span | inc Edge"
+    register: spanedgeoutput
+
+  - name: Create list of IOS STP edge ports
+    set_fact:
+       stp_edge: |
+           {{ spanedgeoutput.stdout_lines[0] |
+             map('regex_replace','(?P<int>^\S*)\s+.*$','\g<int>') |
+             map('join') | list }}
+
+  - debug: var=stp_edge
+
+  - name: disable lldp on access ports
+    ios_config:
+      lines:
+        - no lldp transmit
+        - no lldp receive
+      parents: "interface {{ edge_interface }}"
+      save_when: modified
+    loop: "{{ stp_edge }}"
+    loop_control:
+      loop_var: edge_interface
+
+  - name: enable lldp
+    ios_config:
+      lines:
+        - lldp run
+      save_when: modified


### PR DESCRIPTION
The playbook enables LLDP only on STP P2P ports, while disabling it on STP edge ports. This keeps the resulting topology diagram free from LLDP speaking hosts (and besides, it's probably what you would want anyway ;-)