### PR TITLE
Added condition in case there are no edge ports

### DIFF
--- a/LLDP-to-Graph/disable-LLDP-on-edge.yml
+++ b/LLDP-to-Graph/disable-LLDP-on-edge.yml
@@ -30,6 +30,7 @@
     loop: "{{ stp_edge }}"
     loop_control:
       loop_var: edge_interface
+    when: edge_interface | length > 0
 
   - name: enable lldp
     ios_config:


### PR DESCRIPTION
On switches which do not have any STP 'Edge' ports the 'stp_edge' list turns up empty, causing the ios_command module to attempt to configure a non-existing interface, resulting in an error. The added condition addresses this.